### PR TITLE
[API] resolve deprecation error

### DIFF
--- a/src/api/endpoints/drive/files/create.js
+++ b/src/api/endpoints/drive/files/create.js
@@ -23,7 +23,7 @@ module.exports = (file, params, user) =>
 	new Promise(async (res, rej) =>
 {
 	const buffer = fs.readFileSync(file.path);
-	fs.unlink(file.path);
+	fs.unlink(file.path, (err) => { if (err) console.log(err) });
 
 	// Get 'name' parameter
 	let name = file.originalname;


### PR DESCRIPTION
error detail:
	DeprecationWarning: Calling an asynchronous function without callback is deprecated.

コールバック無しに非同期処理を行うなという内容の非推奨エラーを解消します