### PR TITLE
[utils] dependencyInfo: update MongoDB regexp

### DIFF
--- a/src/utils/dependencyInfo.ts
+++ b/src/utils/dependencyInfo.ts
@@ -9,7 +9,7 @@ export default class {
 	}
 
 	showAll(): void {
-		this.show('MongoDB', 'mongo --version', x => x.match(/^MongoDB shell version: (.*)\r?\n$/));
+		this.show('MongoDB', 'mongo --version', x => x.match(/^MongoDB shell version:? (.*)\r?\n/));
 		this.show('Redis', 'redis-server --version', x => x.match(/v=([0-9\.]*)/));
 		this.show('GraphicsMagick', 'gm -version', x => x.match(/^GraphicsMagick ([0-9\.]*) .*/));
 	}


### PR DESCRIPTION
以前のMongoDBの出力は以下のようなものでした
```sh
$ mongo --version
MongoDB shell version: 3.2.9
```
最新のバージョンではこうです
```sh
$ mongo --version
MongoDB shell version v3.4.1
git version: 5e103c4f5583e2566a45d740225dc250baacfbd7
OpenSSL version: OpenSSL 1.0.1f 6 Jan 2014
allocator: tcmalloc
modules: none
build environment:
    distmod: ubuntu1404
    distarch: x86_64
    target_arch: x86_64
```
コロンがなくなり、さらに情報が表示されるようになりました。以前のバージョンも含めて包括的に対応するため、コロンをあってもなくてもよいに変更、また改行の後の内容に感知しないように変更しました