### PR TITLE
投稿表示`header`改良

### DIFF
--- a/src/web/app/desktop/tags/post-preview.tag
+++ b/src/web/app/desktop/tags/post-preview.tag
@@ -45,31 +45,31 @@
 					width calc(100% - 68px)
 
 					> header
-						margin-bottom 4px
+						display flex
+						margin 4px 0
 						white-space nowrap
 
 						> .name
-							display inline
-							margin 0
+							margin 0 .5em 0 0
 							padding 0
 							color #607073
 							font-size 1em
+							line-height 1.1em
 							font-weight 700
 							text-align left
 							text-decoration none
+							white-space normal
 
 							&:hover
 								text-decoration underline
 
 						> .username
 							text-align left
-							margin 0 0 0 8px
+							margin 0 .5em 0 0
 							color #d1d8da
 
 						> .time
-							position absolute
-							top 0
-							right 0
+							margin-left auto
 							color #b2b8bb
 
 					> .body

--- a/src/web/app/desktop/tags/timeline-post-sub.tag
+++ b/src/web/app/desktop/tags/timeline-post-sub.tag
@@ -63,6 +63,7 @@
 							display block
 							margin 0 .5em 0 0
 							padding 0
+							overflow hidden
 							color #607073
 							font-size 1em
 							font-weight 700

--- a/src/web/app/mobile/tags/timeline-post-sub.tag
+++ b/src/web/app/mobile/tags/timeline-post-sub.tag
@@ -56,7 +56,6 @@
 
 					> header
 						display flex
-						flex-wrap wrap
 						margin-bottom 2px
 						white-space nowrap
 

--- a/src/web/app/mobile/tags/timeline-post.tag
+++ b/src/web/app/mobile/tags/timeline-post.tag
@@ -147,7 +147,6 @@
 
 					> header
 						display flex
-						flex-wrap wrap
 						white-space nowrap
 
 						@media (min-width 500px)
@@ -179,7 +178,7 @@
 
 						> .username
 							text-align left
-							margin 0
+							margin 0 0.5em 0 0
 							color #ccc
 
 						> .created-at


### PR DESCRIPTION
- モバイルも(デスクトップに倣い)タイムライン上では1行に
- `src/web/app/desktop/tags/timeline-post-sub.tag`修正
- `post-preview`もflexbox化