### PR TITLE
fix(package): update riot-tag-loader to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
 		"request": "2.83.0",
 		"rimraf": "2.6.2",
 		"riot": "3.7.4",
-		"riot-tag-loader": "1.0.0",
+		"riot-tag-loader": "2.0.0",
 		"rndstr": "1.0.0",
 		"s-age": "1.1.0",
 		"seedrandom": "2.4.3",


### PR DESCRIPTION
Closes #1042