### PR TITLE
Specify ImageMagick version (7.0+)

### DIFF
--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -30,7 +30,7 @@ Please install and setup these softwares:
 * *Node.js* and *npm*
 * **[MongoDB](https://www.mongodb.com/)**
 * **[Redis](https://redis.io/)**
-* **[ImageMagick](http://www.imagemagick.org/script/index.php)**
+* **[ImageMagick](http://www.imagemagick.org/script/index.php)** >= 7.0
 
 ##### Optional
 * [Elasticsearch](https://www.elastic.co/) - used to provide searching feature instead of MongoDB


### PR DESCRIPTION
Misskey needs the `magick` command, which is not available with ImageMagick <7

![screenshot_15-04-2018_12-58-37](https://user-images.githubusercontent.com/11699655/38777712-db154c28-40ac-11e8-8d97-ae229bce7835.png)