### PR TITLE
Fix can't communicate with other Misskey

### DIFF
--- a/src/queue/processors/http/process-inbox.ts
+++ b/src/queue/processors/http/process-inbox.ts
@@ -33,6 +33,11 @@ export default async (job: kue.Job, done): Promise<void> => {
 		}
 
 		user = await User.findOne({ usernameLower: username, host: host.toLowerCase() }) as IRemoteUser;
+
+		// アクティビティを送信してきたユーザーがまだMisskeyサーバーに登録されていなかったら登録する
+		if (user === null) {
+			user = await resolvePerson(activity.actor);
+		}
 	} else {
 		user = await User.findOne({
 			host: { $ne: null },

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -40,5 +40,10 @@ export default (user: ILocalUser, url: string, object) => new Promise((resolve, 
 		keyId: `acct:${user.username}@${config.host}`
 	});
 
+	// Signature: Signature ... => Signature: ...
+	let sig = req.getHeader('Signature').toString();
+	sig = sig.replace(/^Signature /, '');
+	req.setHeader('Signature', sig);
+
 	req.end(JSON.stringify(object));
 });


### PR DESCRIPTION
Misskey同士でフォロー等できない件の修正

1. サーバからサーバーへのリクエストのSignatureヘッダがおかしくて、受け側サーバーで401になってしまうのを修正
OK ```Signature: keyId="...```
NG ```Signature: Signature keyId="...```
Mastodonではおかしくても動いてしまっていた？

2. MisskeyからMisskeyに初めてのユーザーが来た時にユーザーが作成されないのを修正