### PR TITLE
Fix url preview

### DIFF
--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
 		} else if (url.hostname == 'youtu.be') {
 			this.youtubeId = url.pathname;
 		} else {
-			fetch('/url?url=' + this.url).then(res => {
+			fetch('/url?url=' + encodeURIComponent(this.url)).then(res => {
 				res.json().then(info => {
 					this.title = info.title;
 					this.description = info.description;

--- a/src/server/web/url-preview.ts
+++ b/src/server/web/url-preview.ts
@@ -14,7 +14,7 @@ module.exports = async (ctx: Koa.Context) => {
 
 function wrap(url: string): string {
 	return url != null
-		? url.startsWith('https://')
+		? url.startsWith('https://') || url.startsWith('data:')
 			? url
 			: `https://images.weserv.nl/?url=${encodeURIComponent(url.replace(/^http:\/\//, ''))}`
 		: null;

--- a/src/server/web/url-preview.ts
+++ b/src/server/web/url-preview.ts
@@ -16,6 +16,6 @@ function wrap(url: string): string {
 	return url != null
 		? url.startsWith('https://')
 			? url
-			: `https://images.weserv.nl/?url=${url.replace(/^http:\/\//, '')}`
+			: `https://images.weserv.nl/?url=${encodeURIComponent(url.replace(/^http:\/\//, ''))}`
 		: null;
 }


### PR DESCRIPTION
以下の修正
- `&`を含むURLのプレビューができない
- プレビューに`data:image`なURLが含まれていた場合にエラーになる