### PR TITLE
Stop webpack on URL error, otherwise gulp continues

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -53,5 +53,5 @@ function normalizeUrl(url: string) {
 
 function urlError(url: string) {
 	console.error(`「${url}」は、正しいURLではありません。先頭に http:// または https:// をつけ忘れてないかなど確認してください。`);
-	process.exit();
+	process.exit(99);
 }


### PR DESCRIPTION
````
$ webpack && gulp build
「dont.know.yet」は、正しいURLではありません。先頭に http:// または https:// をつけ忘れてないかなど確認してください。
[00:28:15] Requiring external module ts-node/register
/**
node-macaddress: Unkown os.platform(), defaulting to `unix'.
Error: Cannot find module './built/client/meta.json'
    at Function.Module._resolveFilename (module.js:543:15)
    at Function.Module._load (module.js:470:25)
    at Module.require (module.js:593:17)
    at require (internal/module.js:11:18)
/**
 * Config loader
    at Object.<anonymous> (/usr/home/saper/sw/misskey/gulpfile.ts:24:16)
    at Module._compile (module.js:649:30)
    at Module.m._compile (/usr/home/saper/sw/misskey/node_modules/ts-node/src/index.ts:402:23)
    at Module._extensions..js (module.js:660:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/usr/home/saper/sw/misskey/node_modules/ts-node/src/index.ts:405:12)
    at Module.load (module.js:561:32)
error Command failed with exit code 1.
````