### PR TITLE
Fix #1759 (Improve note-header)

### DIFF
--- a/src/client/app/common/views/components/note-header.vue
+++ b/src/client/app/common/views/components/note-header.vue
@@ -57,7 +57,6 @@ root(isDark)
 
 	> .name
 		display block
-		flex-shrink 0
 		margin 0 .5em 0 0
 		padding 0
 		overflow hidden
@@ -91,6 +90,7 @@ root(isDark)
 		overflow hidden
 		text-overflow ellipsis
 		color isDark ? #606984 : #ccc
+		flex-shrink 10000
 
 	> .info
 		margin-left auto


### PR DESCRIPTION
`flex-shrink`を`.name : .username = 0 : 1`にすると[このように](https://misskey.xyz/notes/5b2c5aad40872b0bad399e5f)なってしまうことに気が付きました。

結局`.name : .username = 1 : 10000`にするほうがよさそうです。